### PR TITLE
Release 2.5.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -94,6 +94,7 @@ sass:
 latest_pegasus_version: master
 pegasus_versions:
 - master
+- 2.5.0
 - 2.4.0
 - 2.3.0
 - 2.2.0

--- a/_docs/en/2.4.0/compile-by-docker.md
+++ b/_docs/en/2.4.0/compile-by-docker.md
@@ -11,7 +11,7 @@ Pegasus encapsulates the building environments into [docker images](https://hub.
 
 For example, you can use the image based on `Ubuntu 20.04`:
 ```sh
-docker pull apache/pegasus:build-env-ubuntu2004
+docker pull apache/pegasus:build-env-ubuntu2004-v2.4
 ```
 
 ## Compilation
@@ -20,7 +20,7 @@ Please refer to [Downloads](/docs/downloads) to fetch the sources under a direct
 
 ```sh
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.4 \
            /bin/bash -c "cd /root/pegasus; ./run.sh build -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -32,7 +32,7 @@ Package server binaries for deployment:
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.4 \
            /bin/bash -c "./run.sh pack_server"
 ```
 
@@ -40,7 +40,7 @@ Package client libraries for C/C++ development:
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.4 \
            /bin/bash -c "./run.sh pack_client"
 ```
 
@@ -48,7 +48,7 @@ Package toolset which includes various tools (shell, bench):
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.4 \
            /bin/bash -c "./run.sh pack_tools"
 ```
 

--- a/_docs/en/2.5.0/compile-by-docker.md
+++ b/_docs/en/2.5.0/compile-by-docker.md
@@ -1,8 +1,8 @@
 ---
-permalink: 2.4.0/docs/build/compile-by-docker/
+permalink: 2.5.0/docs/build/compile-by-docker/
 redirect_from:
-  - 2.4.0/docs/build/compile-by-docker/
-version: 2.4.0
+  - 2.5.0/docs/build/compile-by-docker/
+version: 2.5.0
 ---
 
 ## Download the docker image
@@ -10,7 +10,7 @@ version: 2.4.0
 Pegasus encapsulates the building environments into [docker images](https://hub.docker.com/r/apache/pegasus/tags?page=1&name=env), you can build directly based on these environments.
 
 For example, you can use the image based on `Ubuntu 20.04`:
-```sh
+```bash
 docker pull apache/pegasus:build-env-ubuntu2004
 ```
 
@@ -18,13 +18,31 @@ docker pull apache/pegasus:build-env-ubuntu2004
 
 Please refer to [Downloads](/docs/downloads) to fetch the sources under a directory (`/your/local/apache-pegasus-source`). Then run the following command:
 
-```sh
+If you want to run tests, you should build Pegasus by the following command:
+
+```bash
+docker run -v /your/local/apache-pegasus-source:/root/pegasus \
+           apache/pegasus:build-env-ubuntu2004 \
+           /bin/bash -c "cd /root/pegasus; ./run.sh build --test -c --clear_thirdparty -j $(nproc)"
+```
+
+If you want to build Pegasus without runing tests, just execute the following command:
+
+```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
            apache/pegasus:build-env-ubuntu2004 \
            /bin/bash -c "cd /root/pegasus; ./run.sh build -c --clear_thirdparty -j $(nproc)"
 ```
 
-The output of compilation will be placed under `DSN_ROOT` of the source directory. It includes `bin`, `include` and `lib`.
+The output of compilation will be placed under `build/latest/output/` of the source directory. It includes `bin`, `include` and `lib`.
+
+## Run tests
+
+```bash
+docker run -v /your/local/apache-pegasus-source:/root/pegasus \
+           apache/pegasus:build-env-ubuntu2004 \
+           /bin/bash -c "cd /root/pegasus; ./run.sh test"
+```
 
 ## Packaging
 

--- a/_docs/en/2.5.0/compile-by-docker.md
+++ b/_docs/en/2.5.0/compile-by-docker.md
@@ -11,7 +11,7 @@ Pegasus encapsulates the building environments into [docker images](https://hub.
 
 For example, you can use the image based on `Ubuntu 20.04`:
 ```bash
-docker pull apache/pegasus:build-env-ubuntu2004
+docker pull apache/pegasus:build-env-ubuntu2004-v2.5
 ```
 
 ## Compilation
@@ -22,7 +22,7 @@ If you want to run tests, you should build Pegasus by the following command:
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "cd /root/pegasus; ./run.sh build --test -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -30,7 +30,7 @@ If you want to build Pegasus without runing tests, just execute the following co
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "cd /root/pegasus; ./run.sh build -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -40,7 +40,7 @@ The output of compilation will be placed under `build/latest/output/` of the sou
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "cd /root/pegasus; ./run.sh test"
 ```
 
@@ -50,7 +50,7 @@ Package server binaries for deployment:
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "./run.sh pack_server"
 ```
 
@@ -58,7 +58,7 @@ Package client libraries for C/C++ development:
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "./run.sh pack_client"
 ```
 
@@ -66,7 +66,7 @@ Package toolset which includes various tools (shell, bench):
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "./run.sh pack_tools"
 ```
 

--- a/_docs/en/2.5.0/compile-from-source.md
+++ b/_docs/en/2.5.0/compile-from-source.md
@@ -1,0 +1,67 @@
+---
+permalink: 2.5.0/docs/build/compile-from-source/
+redirect_from:
+  - 2.5.0/docs/build/compile-from-source/
+version: 2.5.0
+---
+
+Since 2.4.0, Pegasus supports to build both on Linux and macOS. Please don't hesitate to contact us via [Github Issues]({{ site.pegasus_github_url }}/issues) when you encountered any problem.
+
+## Requirements
+
+- GCC 5.4.0+
+- CMake 3.11.0+
+
+## Linux environment
+
+You can refer to the docker images to install dependencies and set environment variables. For example:
+- [CentOS 7](https://github.com/apache/incubator-pegasus/blob/master/docker/pegasus-build-env/centos7/Dockerfile)
+- [Ubuntu 18.04](https://github.com/apache/incubator-pegasus/blob/master/docker/pegasus-build-env/ubuntu1804/Dockerfile)
+- [Ubuntu 20.04](https://github.com/apache/incubator-pegasus/blob/master/docker/pegasus-build-env/ubuntu2004/Dockerfile)
+- [Ubuntu 22.04](https://github.com/apache/incubator-pegasus/blob/master/docker/pegasus-build-env/ubuntu2204/Dockerfile)
+
+## Compilation
+
+Please refer to [Downloads](/docs/downloads) to fetch the sources。
+
+If you want to run tests, you should build Pegasus by the following command:
+
+```bash
+./run.sh build --test -c --clear_thirdparty -j $(nproc)
+```
+
+If you want to build Pegasus without runing tests, just execute the following command:
+
+```bash
+./run.sh build -c --clear_thirdparty -j $(nproc)
+```
+
+The output of compilation will be placed under `build/latest/output/` of the source directory. It includes `bin`, `include` and `lib`.
+
+## Run tests
+
+```bash
+./run.sh test
+```
+
+## Packaging
+
+Package server binaries for development:
+
+```bash
+./run.sh pack_server
+```
+
+Package client libraries for C/C++ development:
+
+```bash
+./run.sh pack_client
+```
+
+Package toolset which includes various tools (shell, bench):
+
+```bash
+./run.sh pack_tools
+```
+
+If this is your first time compiling Pegasus, it's recommended to try [onebox](/overview/onebox).

--- a/_docs/en/build/compile-by-docker.md
+++ b/_docs/en/build/compile-by-docker.md
@@ -11,7 +11,7 @@ Pegasus encapsulates the building environments into [docker images](https://hub.
 
 For example, you can use the image based on `Ubuntu 20.04`:
 ```bash
-docker pull apache/pegasus:build-env-ubuntu2004
+docker pull apache/pegasus:build-env-ubuntu2004-master
 ```
 
 ## Compilation
@@ -22,7 +22,7 @@ If you want to run tests, you should build Pegasus by the following command:
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "cd /root/pegasus; ./run.sh build --test -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -30,7 +30,7 @@ If you want to build Pegasus without runing tests, just execute the following co
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "cd /root/pegasus; ./run.sh build -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -40,7 +40,7 @@ The output of compilation will be placed under `build/latest/output/` of the sou
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "cd /root/pegasus; ./run.sh test"
 ```
 
@@ -50,7 +50,7 @@ Package server binaries for deployment:
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "./run.sh pack_server"
 ```
 
@@ -58,7 +58,7 @@ Package client libraries for C/C++ development:
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "./run.sh pack_client"
 ```
 
@@ -66,7 +66,7 @@ Package toolset which includes various tools (shell, bench):
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "./run.sh pack_tools"
 ```
 

--- a/_docs/en/downloads.md
+++ b/_docs/en/downloads.md
@@ -27,6 +27,10 @@ We recommend downloading the signed source release that follows [ASF Release Pol
 [2.4.0-asc]: https://downloads.apache.org/incubator/pegasus/2.4.0/apache-pegasus-2.4.0-incubating-src.zip.asc
 [2.4.0-sha]: https://downloads.apache.org/incubator/pegasus/2.4.0/apache-pegasus-2.4.0-incubating-src.zip.sha512
 [2.4.0-rn]: https://cwiki.apache.org/confluence/display/PEGASUS/Apache+Pegasus+2.4.0+Release+Notes
+[2.5.0-src]: https://www.apache.org/dyn/closer.lua?path=/incubator/pegasus/2.5.0/apache-pegasus-2.5.0-incubating-src.zip
+[2.5.0-asc]: https://downloads.apache.org/incubator/pegasus/2.5.0/apache-pegasus-2.5.0-incubating-src.zip.asc
+[2.5.0-sha]: https://downloads.apache.org/incubator/pegasus/2.5.0/apache-pegasus-2.5.0-incubating-src.zip.sha512
+[2.5.0-rn]: https://cwiki.apache.org/confluence/display/PEGASUS/Apache+Pegasus+2.5.0+Release+Notes
 
 | Name                 | Package             | Signature        | Checksum            | Release Notes          |
 |----------------------|---------------------|------------------|---------------------|------------------------|
@@ -34,4 +38,5 @@ We recommend downloading the signed source release that follows [ASF Release Pol
 | Apache Pegasus 2.2.0 | [Source][2.2.0-src] | [asc][2.2.0-asc] | [sha512][2.2.0-sha] | [2021-06-27][2.2.0-rn] |
 | Apache Pegasus 2.3.0 | [Source][2.3.0-src] | [asc][2.3.0-asc] | [sha512][2.3.0-sha] | [2021-11-26][2.3.0-rn] |
 | Apache Pegasus 2.4.0 | [Source][2.4.0-src] | [asc][2.4.0-asc] | [sha512][2.4.0-sha] | [2022-10-22][2.4.0-rn] |
+| Apache Pegasus 2.5.0 | [Source][2.5.0-src] | [asc][2.5.0-asc] | [sha512][2.5.0-sha] | [2022-12-01][2.5.0-rn] |
 

--- a/_docs/zh/2.4.0/compile-by-docker.md
+++ b/_docs/zh/2.4.0/compile-by-docker.md
@@ -13,7 +13,7 @@ Pegasus将编译环境封装至[Docker镜像](https://hub.docker.com/r/apache/pe
 比如，你可以使用基于`Ubuntu 20.04`的镜像：
 
 ```sh
-docker pull apache/pegasus:build-env-ubuntu2004
+docker pull apache/pegasus:build-env-ubuntu2004-v2.4
 ```
 
 ## 编译
@@ -22,7 +22,7 @@ docker pull apache/pegasus:build-env-ubuntu2004
 
 ```sh
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.4 \
            /bin/bash -c "cd /root/pegasus; ./run.sh build -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -34,7 +34,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.4 \
            /bin/bash -c "./run.sh pack_server"
 ```
 
@@ -42,7 +42,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.4 \
            /bin/bash -c "./run.sh pack_client"
 ```
 
@@ -50,7 +50,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.4 \
            /bin/bash -c "./run.sh pack_tools"
 ```
 

--- a/_docs/zh/2.5.0/compile-by-docker.md
+++ b/_docs/zh/2.5.0/compile-by-docker.md
@@ -13,7 +13,7 @@ Pegasus将编译环境封装至[Docker镜像](https://hub.docker.com/r/apache/pe
 比如，你可以使用基于`Ubuntu 20.04`的镜像：
 
 ```bash
-docker pull apache/pegasus:build-env-ubuntu2004
+docker pull apache/pegasus:build-env-ubuntu2004-v2.5
 ```
 
 ## 编译
@@ -24,7 +24,7 @@ docker pull apache/pegasus:build-env-ubuntu2004
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "cd /root/pegasus; ./run.sh build --test -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -32,7 +32,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "cd /root/pegasus; ./run.sh build -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -42,7 +42,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "cd /root/pegasus; ./run.sh test"
 ```
 
@@ -52,7 +52,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "./run.sh pack_server"
 ```
 
@@ -60,7 +60,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "./run.sh pack_client"
 ```
 
@@ -68,7 +68,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-v2.5 \
            /bin/bash -c "./run.sh pack_tools"
 ```
 

--- a/_docs/zh/2.5.0/compile-by-docker.md
+++ b/_docs/zh/2.5.0/compile-by-docker.md
@@ -1,24 +1,26 @@
 ---
-permalink: docs/build/compile-by-docker/
+permalink: 2.5.0/docs/build/compile-by-docker/
 redirect_from:
-  - master/docs/build/compile-by-docker/
-version: master
+  - 2.5.0/docs/build/compile-by-docker/
+  - docs/installation
+version: 2.5.0
 ---
 
-## Download the docker image
+## 下载Docker镜像
 
-Pegasus encapsulates the building environments into [docker images](https://hub.docker.com/r/apache/pegasus/tags?page=1&name=env), you can build directly based on these environments.
+Pegasus将编译环境封装至[Docker镜像](https://hub.docker.com/r/apache/pegasus/tags?page=1&name=env)中，这里包含有多个Linux发行版，你可以直接基于这些环境编译代码。
 
-For example, you can use the image based on `Ubuntu 20.04`:
+比如，你可以使用基于`Ubuntu 20.04`的镜像：
+
 ```bash
 docker pull apache/pegasus:build-env-ubuntu2004
 ```
 
-## Compilation
+## 编译
 
-Please refer to [Downloads](/docs/downloads) to fetch the sources under a directory (`/your/local/apache-pegasus-source`). Then run the following command:
+请先参考[下载文档](/docs/downloads)获取源码到某目录（`/your/local/apache-pegasus-source`）下。随后运行以下命令：
 
-If you want to run tests, you should build Pegasus by the following command:
+如果你想要执行测试程序，需要用如下命令来编译Pegasus：
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
@@ -26,7 +28,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
            /bin/bash -c "cd /root/pegasus; ./run.sh build --test -c --clear_thirdparty -j $(nproc)"
 ```
 
-If you want to build Pegasus without runing tests, just execute the following command:
+如果不需要执行测试程序，只是单纯想编译Pegasus，使用如下命令即可：
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
@@ -34,9 +36,9 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
            /bin/bash -c "cd /root/pegasus; ./run.sh build -c --clear_thirdparty -j $(nproc)"
 ```
 
-The output of compilation will be placed under `build/latest/output/` of the source directory. It includes `bin`, `include` and `lib`.
+编译的结果会被放在项目根目录的`build/latest/output/`文件夹下，其中包含`bin`、`include`以及`lib`目录。
 
-## Run tests
+## 执行测试程序
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
@@ -44,9 +46,9 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
            /bin/bash -c "cd /root/pegasus; ./run.sh test"
 ```
 
-## Packaging
+## 编译打包
 
-Package server binaries for deployment:
+打包server端程序包，用于服务部署：
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
@@ -54,7 +56,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
            /bin/bash -c "./run.sh pack_server"
 ```
 
-Package client libraries for C/C++ development:
+打包client端库，用于C/C++端客户端开发：
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
@@ -62,7 +64,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
            /bin/bash -c "./run.sh pack_client"
 ```
 
-Package toolset which includes various tools (shell, bench):
+打包tools工具集，里面包含了各种工具（shell、bench）：
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
@@ -70,4 +72,4 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
            /bin/bash -c "./run.sh pack_tools"
 ```
 
-If this is your first time compiling Pegasus, it's recommended to try [onebox](/overview/onebox).
+编译成功后，推荐先[体验onebox集群](/overview/onebox)。

--- a/_docs/zh/2.5.0/compile-from-source.md
+++ b/_docs/zh/2.5.0/compile-from-source.md
@@ -1,0 +1,67 @@
+---
+permalink: 2.5.0/docs/build/compile-from-source/
+redirect_from:
+  - 2.5.0/docs/build/compile-from-source/
+  - docs/installation
+version: 2.5.0
+---
+
+从2.4.0开始，Pegasus支持Linux和macOS平台进行源码编译。编译过程中遇到问题，可以通过[Github Issues]({{ site.pegasus_github_url }}/issues)向我们咨询。
+
+## 环境要求
+
+- GCC 5.4.0+
+- CMake 3.11.0+
+
+## Linux环境配置
+
+你可以参考的Docker镜像来安装依赖并设置环境变量。例如：
+
+- [CentOS 7](https://github.com/apache/incubator-pegasus/blob/master/docker/pegasus-build-env/centos7/Dockerfile)
+- [Ubuntu 18.04](https://github.com/apache/incubator-pegasus/blob/master/docker/pegasus-build-env/ubuntu1804/Dockerfile)
+- [Ubuntu 20.04](https://github.com/apache/incubator-pegasus/blob/master/docker/pegasus-build-env/ubuntu2004/Dockerfile)
+- [Ubuntu 22.04](https://github.com/apache/incubator-pegasus/blob/master/docker/pegasus-build-env/ubuntu2204/Dockerfile)
+
+## 源码编译
+
+请先参考[下载文档](/docs/downloads)获取源码。
+
+如果你想要执行测试程序，需要用如下命令来编译Pegasus：
+```bash
+./run.sh build --test -c --clear_thirdparty -j $(nproc)
+```
+
+如果不需要执行测试程序，只是单纯想编译Pegasus，使用如下命令即可：
+```bash
+./run.sh build -c --clear_thirdparty -j $(nproc)
+```
+
+编译后输出会放在当前目录的`build/latest/output/`目录下，里面包含`bin`、`include`以及`lib`目录。
+
+## 执行测试程序
+
+```bash
+./run.sh test
+```
+
+## 编译打包
+
+打包server端程序包，用于服务部署：
+
+```bash
+./run.sh pack_server
+```
+
+打包client端库，用于C/C++端客户端开发：
+
+```bash
+./run.sh pack_client
+```
+
+打包tools工具集，里面包含了各种工具（shell、bench）：
+
+```bash
+./run.sh pack_tools
+```
+
+编译成功后，推荐先[体验onebox集群](/overview/onebox)。

--- a/_docs/zh/build/compile-by-docker.md
+++ b/_docs/zh/build/compile-by-docker.md
@@ -13,7 +13,7 @@ Pegasus将编译环境封装至[Docker镜像](https://hub.docker.com/r/apache/pe
 比如，你可以使用基于`Ubuntu 20.04`的镜像：
 
 ```bash
-docker pull apache/pegasus:build-env-ubuntu2004
+docker pull apache/pegasus:build-env-ubuntu2004-master
 ```
 
 ## 编译
@@ -24,7 +24,7 @@ docker pull apache/pegasus:build-env-ubuntu2004
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "cd /root/pegasus; ./run.sh build --test -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -32,7 +32,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "cd /root/pegasus; ./run.sh build -c --clear_thirdparty -j $(nproc)"
 ```
 
@@ -42,7 +42,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "cd /root/pegasus; ./run.sh test"
 ```
 
@@ -52,7 +52,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "./run.sh pack_server"
 ```
 
@@ -60,7 +60,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "./run.sh pack_client"
 ```
 
@@ -68,7 +68,7 @@ docker run -v /your/local/apache-pegasus-source:/root/pegasus \
 
 ```bash
 docker run -v /your/local/apache-pegasus-source:/root/pegasus \
-           apache/pegasus:build-env-ubuntu2004 \
+           apache/pegasus:build-env-ubuntu2004-master \
            /bin/bash -c "./run.sh pack_tools"
 ```
 


### PR DESCRIPTION
Since version 2.5.0 has been released, we could add docs for 2.5.0 for official website, such as download links and building commands:

- https://github.com/apache/incubator-pegasus/releases/tag/v2.5.0
- https://cwiki.apache.org/confluence/display/PEGASUS/Apache+Pegasus+2.5.0+Release+Notes