### PR TITLE
Remove Google Analytics

### DIFF
--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,8 +1,0 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
-<script>
-  window['ga-disable-{{ site.google_analytics }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '{{ site.google_analytics }}');
-</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,4 @@
     <script src="/assets/js/all.min.js"></script>
     <script src="/assets/js/docsearch.v3.js"></script>
     {% seo %}
-    {%- if site.google_analytics -%}
-    {%- include google-analytics.html -%}
-    {%- endif -%}
 </head>


### PR DESCRIPTION
The pegasus website is currently included in a report to the **_Privacy Committee_** for using **_Google Analytics_**. From what I can see it looks like this is not the case, but is probably because of the following file in your website repo:

- https://github.com/apache/incubator-pegasus-website/blob/master/_includes/google-analytics.html

It would be really helpful if you could remove that file so that pegasus doesn't incorrectly get flagged.

See https://github.com/apache/incubator-pegasus/issues/2189