### PR TITLE
Remove Google Analytics #91 (asf-site branch)

### DIFF
--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,8 +1,0 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
-<script>
-  window['ga-disable-{{ site.google_analytics }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '{{ site.google_analytics }}');
-</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,4 @@
     <link rel="shortcut icon" href="{{ site.baseurl }}/assets/images/favicon.ico">
     <script src="https://cdn.bootcdn.net/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
     {% seo %}
-    {%- if site.google_analytics -%}
-      {%- include google-analytics.html -%}
-    {%- endif -%}
 </head>


### PR DESCRIPTION
Hi Pegasus Team!

The pegasus website is currently included in a report to the Privacy Committee for using Google Analytics. I realize this is a _**false positive**_, since the website is served from the **output** folder now, but it would be really helpful to remove this file in order to get Pegasus off the report.

I know I said previously I would try to get the report changed to be _smarter_, but I haven't managed to do that.

Thank You

Niall